### PR TITLE
Fix PluginFS datastore persistence

### DIFF
--- a/src/src/utils/fileSystem.ts
+++ b/src/src/utils/fileSystem.ts
@@ -13,7 +13,7 @@ export class FileSystem {
     }
 
     write = async (context: any, path: string, content: string, enableAppendMode: boolean): Promise<boolean> => {
-        return await context.fs.write(path, content, enableAppendMode);
+        return await context.fs.write(path, content, { append: enableAppendMode });
     }
 
     mkdir = async (context: any, path: string): Promise<boolean> => {
@@ -66,10 +66,10 @@ export class FileSystem {
     }
 
     refreshLists = async (context: any) => {
-        const wallpaper = await this.ls(context, './assets/backgrounds/wallpapers');
-        const audio = await this.ls(context, './assets/backgrounds/audio');
-        const banner = await this.ls(context, './assets/icon/regalia-banners');
-        const font = await this.ls(context, './assets/fonts');
+        const wallpaper = await this.ls(context, './assets/backgrounds/wallpapers') ?? [];
+        const audio = await this.ls(context, './assets/backgrounds/audio') ?? [];
+        const banner = await this.ls(context, './assets/icon/regalia-banners') ?? [];
+        const font = await this.ls(context, './assets/fonts') ?? [];
 
         const FILE_REGEX = {
             Wallpaper: /\.(png|jpg|jpeg|gif|bmp|webp|ico|mp4|webm|mkv|mov|avi|wmv|3gp|m4v)$/,

--- a/src/src/utils/themeDataStore.ts
+++ b/src/src/utils/themeDataStore.ts
@@ -10,6 +10,8 @@ let cache: Record<string, any> = {};
 let storageMode: StorageMode = 'datastore';
 let fsContext: any = null;
 let initPromiseResolve: (() => void) | null = null;
+let pendingPersist: Promise<boolean> | null = null;
+let persistAgain = false;
 
 /**
  * A promise that resolves once ElainaData has been fully initialized.
@@ -27,7 +29,7 @@ async function persistToFile(): Promise<boolean> {
     if (storageMode !== 'fs' || !fsContext) return false;
     try {
         const json = JSON.stringify(cache, null, 2);
-        const success = await fsContext.fs.write(DATA_FILE_PATH, json, false);
+        const success = await fsContext.fs.write(DATA_FILE_PATH, json, { append: false });
         if (!success) {
             error('context.fs.write returned false — data may not be persisted');
         }
@@ -36,6 +38,26 @@ async function persistToFile(): Promise<boolean> {
         error('Failed to persist ElainaData to file', err);
         return false;
     }
+}
+
+function queuePersist(): Promise<boolean> {
+    if (pendingPersist) {
+        persistAgain = true;
+        return pendingPersist;
+    }
+
+    pendingPersist = (async () => {
+        let success = true;
+        do {
+            persistAgain = false;
+            success = await persistToFile();
+        } while (persistAgain);
+        return success;
+    })().finally(() => {
+        pendingPersist = null;
+    });
+
+    return pendingPersist;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,8 +195,7 @@ const ElainaData = {
     set(key: string, value: any): boolean {
         if (storageMode === 'fs') {
             cache[key] = value;
-            // Fire-and-forget but no debounce — persist every write
-            persistToFile();
+            queuePersist();
             return true;
         }
         return datastoreSet(key, value);
@@ -201,7 +222,7 @@ const ElainaData = {
         if (storageMode === 'fs') {
             if (cache.hasOwnProperty(key)) {
                 delete cache[key];
-                persistToFile();
+                queuePersist();
                 return true;
             }
             return false;
@@ -215,8 +236,7 @@ const ElainaData = {
     restoreDefaults(): void {
         if (storageMode === 'fs') {
             cache = {};
-            // Flush immediately — user is about to reload
-            persistToFile();
+            queuePersist();
         } else {
             window.DataStore.set("ElainaTheme", {});
         }
@@ -240,7 +260,7 @@ const ElainaData = {
     setAll(data: Record<string, any>): void {
         if (storageMode === 'fs') {
             cache = { ...data };
-            persistToFile();
+            queuePersist();
         } else {
             window.DataStore.set("ElainaTheme", data);
         }
@@ -253,7 +273,7 @@ const ElainaData = {
 
     /** Force an immediate flush of cache to file (fs mode only). */
     async flush(): Promise<void> {
-        await persistToFile();
+        await queuePersist();
     }
 };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -63,11 +63,11 @@ interface FileStat {
 
 interface PluginFS {
     read: (path: string) => Promise<string | undefined>
-    write: (path: string, content: string, enableAppendMode: boolean) => Promise<boolean>
+    write: (path: string, content: string, options?: { append?: boolean }) => Promise<boolean>
     mkdir: (path: string) => Promise<boolean>
     stat: (path: string) => Promise<FileStat | undefined>
     ls: (path: string) => Promise<string[] | undefined>
-    rm: (path: string, recursively: boolean) => Promise<number>
+    rm: (path: string, options?: { recursive?: boolean }) => Promise<number>
 }
 
 interface elainaData {


### PR DESCRIPTION
## Summary

Fixes the PluginFS datastore integration on the `File-System-Datastore` branch.

What was wrong:

- `context.fs.write()` was being called as `write(path, content, boolean)`, but PenguLoader's current PluginFS API expects `write(path, content, { append?: boolean })`.
- `ElainaData.set()` fired a filesystem write on every mutation without awaiting, queueing, or coalescing them. That can create overlapping writes to the same JSON file whenever settings/list updates happen quickly.
- `refreshLists()` assumed `context.fs.ls()` always returns an array. PluginFS returns `undefined` for missing/invalid paths, so `.filter()` could crash if an expected asset folder is missing.
- The local PluginFS typings were stale and still described the old boolean write/remove signatures.

What changed:

- Uses `{ append: enableAppendMode }` / `{ append: false }` for PluginFS writes.
- Adds a small queued persistence layer for `ElainaData` so rapid updates collapse into ordered saves instead of many overlapping writes.
- Treats missing list folders as empty arrays in `refreshLists()`.
- Updates local `PluginFS` typings to match PenguLoader's current API shape.

## Validation

- `pnpm lint` passes with the existing warning in `src/src/utils/fileSystem.ts` about a missing JSDoc comment.
- Repository hooks also report an existing wiki metadata warning for `disable-theme-wallpaper`.
- `pnpm build` is currently blocked in a fresh clone because `src/elaina-theme-data/` is gitignored and absent, while `src/src/plugins/autoQueue.ts` imports from it. That folder needs to be present/generated for full TypeScript build validation.

## Context

This was tested while validating PenguLoader PluginFS through live LCUX/CDP. PenguLoader is not adding backwards compatibility for the old boolean `fs.write` signature, so theme code needs to follow the current object-options API.
