### PR TITLE
Fix PluginFS datastore init order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import { ElainaData } from "./src/utils/themeDataStore.ts";
 
 // Importing theme contents
 import "./src/languages.ts";
-import "./src/utils/setTime.ts";
 import { log } from './src/utils/themeLog.ts';
 
 log('By %cElaina Da Catto', 'color: #e4c2b3');
@@ -18,26 +17,73 @@ log('%cMeow ~~~', 'color: #e4c2b3');
 log('Importing theme contents');
 
 // Import server-side backup/restore data service
-import './src/services/backupAndRestoreDatastore';
+import { restoreDefaultDataStore } from './src/services/backupAndRestoreDatastore';
 
-// Import Init modules
-import { Settings } from "./src/plugins/settings.ts";
-import { transparentLobby } from "./src/theme/customUI/transparentLobby.ts";
-import { AutoQueue } from "./src/plugins/autoQueue.ts";
-import { skipHonor } from "./src/plugins/skipHonor.js";
-import /**{ Cdninit } from **/'./src/theme/Cdn.ts';
-import { FileSystem } from "./src/utils/fileSystem.ts";
+let Settings: any;
+let transparentLobby: any;
+let AutoQueue: any;
+let skipHonor: any;
+let FileSystem: any;
+let CheckUpdate: any;
+let ApplyUI: any;
+let Filters: any;
+let LoadCss: any;
+let ThemePresetSettings: any;
+let CustomStatus: any;
+let AutoAccept: any;
+let CustomBeRp: any;
+let CustomSummonerLv: any;
+let LootHelper: any;
+let NameSpoofer: any;
+let OfflineMode: any;
+let Practice5vs5: any;
+let InviteAllFriends: any;
+let ForceJungLane: any;
+let upl: any;
+
+async function loadRuntimeModules() {
+    if (Settings) return;
+
+    ({ Settings } = await import("./src/plugins/settings.ts"));
+    ({ transparentLobby } = await import("./src/theme/customUI/transparentLobby.ts"));
+    ({ AutoQueue } = await import("./src/plugins/autoQueue.ts"));
+    ({ skipHonor } = await import("./src/plugins/skipHonor.js"));
+    ({ FileSystem } = await import("./src/utils/fileSystem.ts"));
+    ({ CheckUpdate } = await import("./src/updates/checkUpdate.ts"));
+    ({ ApplyUI } = await import("./src/theme/loadCustomUi.ts"));
+    ({ Filters } = await import("./src/theme/loadCustomFilters.ts"));
+    ({ LoadCss } = await import("./src/theme/loadCustomCss.ts"));
+    ({ ThemePresetSettings } = await import("./src/plugins/themePresetSettingsTab.ts"));
+    ({ CustomStatus } = await import("./src/plugins/customStatus.ts"));
+    ({ AutoAccept } = await import("./src/plugins/autoAccept.ts"));
+    ({ CustomBeRp } = await import("./src/plugins/customBeRp.ts"));
+    ({ CustomSummonerLv } = await import("./src/plugins/customSummonerLv.ts"));
+    ({ LootHelper } = await import("./src/plugins/lootHelper.ts"));
+    ({ NameSpoofer } = await import("./src/plugins/nameSpoofer.ts"));
+    ({ OfflineMode } = await import("./src/plugins/offlineMode.ts"));
+    ({ Practice5vs5 } = await import("./src/plugins/practice5vs5.ts"));
+    ({ InviteAllFriends } = await import("./src/plugins/inviteAllFriends.ts"));
+    ({ ForceJungLane } = await import("./src/plugins/forceJungleLane.ts"));
+    upl = await import("pengu-upl");
+    await import("./src/plugins/syncUserIcons.ts");
+    await import("./src/utils/debug.ts");
+}
 
 // Export Init
 export async function init(context: any) {
     log('Initializing ElainaData storage');
     await ElainaData.init(context);
+    await restoreDefaultDataStore();
+    ElainaData.set("start-time", Date.now());
+    await loadRuntimeModules();
 
     log('Initializing file system for theme');
     const fileSystem = new FileSystem();
     await fileSystem.init(context);
 
     log('Initializing theme');
+    const { initThemeDataCdn } = await import('./src/theme/Cdn.ts');
+    await initThemeDataCdn();
 
     // createHomePageTab(context);
     Settings(context);
@@ -46,31 +92,6 @@ export async function init(context: any) {
     skipHonor(context);
     // Cdninit(context);
 }
-
-// Import modules
-import { CheckUpdate } from "./src/updates/checkUpdate.ts"
-import { ApplyUI } from "./src/theme/loadCustomUi.ts";
-import { Filters } from "./src/theme/loadCustomFilters.ts"
-import { LoadCss } from "./src/theme/loadCustomCss.ts"
-import { ThemePresetSettings } from "./src/plugins/themePresetSettingsTab.ts"
-
-// Import plugins
-import { CustomStatus } from "./src/plugins/customStatus.ts"
-import { AutoAccept } from "./src/plugins/autoAccept.ts"
-import { CustomBeRp } from "./src/plugins/customBeRp.ts"
-import { CustomSummonerLv } from "./src/plugins/customSummonerLv.ts"
-import { DodgeButton } from "./src/plugins/dodgeButton.ts"
-import { LootHelper } from "./src/plugins/lootHelper.ts"
-import { NameSpoofer } from "./src/plugins/nameSpoofer.ts"
-import { OfflineMode } from "./src/plugins/offlineMode.ts"
-import { Practice5vs5 } from "./src/plugins/practice5vs5.ts"
-import { InviteAllFriends } from "./src/plugins/inviteAllFriends.ts"
-
-// Import other plugins
-import * as upl from "pengu-upl"
-import { ForceJungLane } from "./src/plugins/forceJungleLane.ts"
-import "./src/plugins/syncUserIcons.ts";
-import "./src/utils/debug.ts"
 
 class ElainaTheme {
     async main() {
@@ -153,9 +174,10 @@ class ElainaTheme {
 }
 
 const elainaTheme = new ElainaTheme()
-window.addEventListener("load", async () => {
+export async function load() {
+    await loadRuntimeModules();
     await elainaTheme.main()
 
     // For debug only
     if (ElainaData.get("Dev-mode")) window.upl = upl;
-})
+}

--- a/src/src/otherThings.ts
+++ b/src/src/otherThings.ts
@@ -4,8 +4,10 @@ import { cdnImport } from "./theme/Cdn.ts"
 export function getThemeName(): string | null {
     const error = new Error();
     const stackTrace = error.stack;
-    const scriptPath = stackTrace?.match(/(?:http|https):\/\/[^\s]+\.js/g)?.[0];
-    const match = scriptPath?.match(/\/([^/]+)\/index\.js$/);
+    const scriptPath = stackTrace
+        ?.match(/(?:http|https):\/\/plugins\/[^\s)]+\.js/g)
+        ?.find((url) => !url.includes('/@/'));
+    const match = scriptPath?.match(/\/\/plugins\/([^/?#]+)\//);
     return match ? match[1] : null;
 }
 

--- a/src/src/plugins/settings.ts
+++ b/src/src/plugins/settings.ts
@@ -10,8 +10,6 @@ import { getThemeName } from '../otherThings.ts'
 
 const datapath = `//plugins/${getThemeName()}/`
 
-ElainaData.set("settingsChangenumber", 0)
-
 /** Shows a restart prompt when settings are changed that require a client restart. */
 async function restartAfterChange(el: string, data: string) {
     let lastdata: any = document.getElementById(el)?.getAttribute("lastdatastore")
@@ -126,6 +124,7 @@ export { datapath, restartAfterChange }
  * @author Elaina Da Catto
  */
 export function Settings(context: any) {
+    ElainaData.set("settingsChangenumber", 0)
     settingsUtils(context, structure)
 }
 

--- a/src/src/services/backupAndRestoreDatastore.ts
+++ b/src/src/services/backupAndRestoreDatastore.ts
@@ -65,10 +65,4 @@ const backupRestoreData = new BackupRestoreData()
 const restoreDefaultDataStore = backupRestoreData.restore
 const setDefaultData = backupRestoreData.setDefaultData
 
-try {
-	// Restore Datastore file if no theme's data
-	await restoreDefaultDataStore()
-}
-catch(err:any) { error("Can not restore datastore", err) }
-
-export { setDefaultData }
+export { restoreDefaultDataStore, setDefaultData }

--- a/src/src/theme/Cdn.ts
+++ b/src/src/theme/Cdn.ts
@@ -26,13 +26,16 @@ export async function cdnImport(url: string, errorMsg: any): Promise<any> {
 };
 
 log(cdnServer["cdn-url"])
-if (ElainaData.get("Dev-mode")) {
-    initLink = `//plugins/${getThemeName()}/elaina-theme-data/cdninit.js`;
-    await cdnImport(`//plugins/${getThemeName()}/elaina-theme-data/index.js`, "Failed to load local data");
-} 
-else {
-    initLink = `${cdnServer["cdn-url"]}elaina-theme-data@${cdnServer["version"]}/cdninit.js`;
-    await cdnImport(`${cdnServer["cdn-url"]}elaina-theme-data@${cdnServer["version"]}/index.js`, "Failed to load CDN data");
+
+export async function initThemeDataCdn() {
+    if (ElainaData.get("Dev-mode")) {
+        initLink = `//plugins/${getThemeName()}/elaina-theme-data/cdninit.js`;
+        await cdnImport(`//plugins/${getThemeName()}/elaina-theme-data/index.js`, "Failed to load local data");
+    }
+    else {
+        initLink = `${cdnServer["cdn-url"]}elaina-theme-data@${cdnServer["version"]}/cdninit.js`;
+        await cdnImport(`${cdnServer["cdn-url"]}elaina-theme-data@${cdnServer["version"]}/index.js`, "Failed to load CDN data");
+    }
 }
 
 

--- a/src/src/theme/customUI/customHomepage.ts
+++ b/src/src/theme/customUI/customHomepage.ts
@@ -17,9 +17,6 @@ const datapath: string = `//plugins/${getThemeName()}/`
 const iconFolder: string = `${datapath}assets/icon/`;
 const bgFolder: string = `${datapath}assets/backgrounds/`;
 
-ElainaData.set("Font-folder", `${datapath}assets/fonts/`);
-ElainaData.set("Plugin-folder-name", getThemeName());
-
 let addedBackgrounds = false
 let navbarContentList: any[] = [];
 let haveNewContent = 0
@@ -40,10 +37,13 @@ const defaultData = {
     "WallpaperAudio-timeUpdate": 3000,
 };
 
-setDefaultData(defaultData, false);
+function initHomepageData() {
+    ElainaData.set("Font-folder", `${datapath}assets/fonts/`);
+    ElainaData.set("Plugin-folder-name", getThemeName());
+    setDefaultData(defaultData, false);
+}
 
-// Get Summoner ID and PUUID
-window.setTimeout(async () => {
+async function updateSummonerIdentity() {
     const summonerID: number = await utils.getSummonerID();
     const PUUID: string = await utils.getPUUID();
 
@@ -52,7 +52,7 @@ window.setTimeout(async () => {
 
     log(`%cCurrent summonerID: %c${summonerID}`, 'color: #e4c2b3', 'color: #0070ff');
     log(`%cCurrent PUUID: %c${PUUID}`, 'color: #e4c2b3', 'color: #0070ff');
-}, 7000);
+}
 
 // Create and set new page as Homepage
 export function createHomePageTab(context: any) {
@@ -1248,6 +1248,9 @@ const addHomePage = new AddHomePage()
 /** Manages the custom homepage including wallpapers, audio, navbar buttons, and page listeners. */
 export class HomePage {
     main = () => {
+        initHomepageData()
+        window.setTimeout(updateSummonerIdentity, 7000)
+
         log("Add wallpaper and audio")
         wallpaperAndAudio.addWallpaperElement()
         wallpaperAndAudio.addImageWallpaperElement()

--- a/src/src/utils/themeDataStore.ts
+++ b/src/src/utils/themeDataStore.ts
@@ -9,6 +9,7 @@ type StorageMode = 'fs' | 'datastore';
 let cache: Record<string, any> = {};
 let storageMode: StorageMode = 'datastore';
 let fsContext: any = null;
+let initialized = false;
 let initPromiseResolve: (() => void) | null = null;
 let pendingPersist: Promise<boolean> | null = null;
 let persistAgain = false;
@@ -108,6 +109,7 @@ const ElainaData = {
         if (!context || !context.fs) {
             log('context.fs not available — using DataStore mode');
             storageMode = 'datastore';
+            initialized = true;
             initPromiseResolve?.();
             return;
         }
@@ -144,22 +146,8 @@ const ElainaData = {
                 }
             }
 
-            // Merge any keys that backupAndRestoreDatastore set into DataStore
-            // BEFORE init() was called (top-level await runs first).
-            // This ensures defaults and pre-init writes are not lost.
-            const currentDatastore: Record<string, any> = window.DataStore.get("ElainaTheme", {});
-            let merged = false;
-            for (const [key, value] of Object.entries(currentDatastore)) {
-                if (!cache.hasOwnProperty(key)) {
-                    cache[key] = value;
-                    merged = true;
-                }
-            }
-            if (merged) {
-                log('Merged missing keys from DataStore into fs cache');
-            }
-
             storageMode = 'fs';
+            initialized = true;
 
             // Persist immediately to ensure file is up-to-date
             await persistToFile();
@@ -167,6 +155,7 @@ const ElainaData = {
         } catch (err: any) {
             error('Failed to init ElainaData in fs mode, falling back to DataStore', err);
             storageMode = 'datastore';
+            initialized = true;
         }
 
         initPromiseResolve?.();
@@ -179,6 +168,11 @@ const ElainaData = {
      * @returns The value associated with the key or the fallback.
      */
     get(key: string, fallback: any = null): any {
+        if (!initialized) {
+            error(`ElainaData.get("${key}") called before ElainaData.init()`);
+            return fallback;
+        }
+
         if (storageMode === 'fs') {
             return cache.hasOwnProperty(key) ? cache[key] : fallback;
         }
@@ -193,6 +187,11 @@ const ElainaData = {
      * @returns True if the key was set successfully, false otherwise.
      */
     set(key: string, value: any): boolean {
+        if (!initialized) {
+            error(`ElainaData.set("${key}") called before ElainaData.init()`);
+            return false;
+        }
+
         if (storageMode === 'fs') {
             cache[key] = value;
             queuePersist();
@@ -207,6 +206,11 @@ const ElainaData = {
      * @returns True if the key exists, false otherwise.
      */
     has(key: string): boolean {
+        if (!initialized) {
+            error(`ElainaData.has("${key}") called before ElainaData.init()`);
+            return false;
+        }
+
         if (storageMode === 'fs') {
             return cache.hasOwnProperty(key);
         }
@@ -219,6 +223,11 @@ const ElainaData = {
      * @returns True if the key was removed, false otherwise.
      */
     remove(key: string): boolean {
+        if (!initialized) {
+            error(`ElainaData.remove("${key}") called before ElainaData.init()`);
+            return false;
+        }
+
         if (storageMode === 'fs') {
             if (cache.hasOwnProperty(key)) {
                 delete cache[key];


### PR DESCRIPTION
## Summary

Follow-up to #20 after live testing reported that PluginFS data still felt unstable.

The remaining issue was initialization order, not the PluginFS write API itself. Several modules still touched `ElainaData` while the bundle was being imported, before `ElainaData.init(context)` had loaded `./data/ElainaData.json`. That meant early reads/writes could hit legacy `window.DataStore` or stale default state, while later code read from PluginFS.

## What changed

- Run default datastore restore only after `ElainaData.init(context)` has selected and loaded the storage backend.
- Move `start-time`, `settingsChangenumber`, homepage default data, font folder, plugin folder, and summoner identity writes out of top-level module import execution.
- Make `Cdn.ts` import side-effect-free for `cdnImport`; the Dev-mode local/CDN decision now runs after datastore init.
- Stop merging missing keys from legacy `window.DataStore` into the fs cache on every startup. That could reintroduce stale legacy values and explains settings seeming applied even after being turned off in PluginFS data.
- Add guards in `ElainaData.get/set/has/remove` so accidental pre-init access logs an explicit error instead of silently using the wrong backend.

## Validation

- `pnpm build` passes after restoring the repo's ignored `src/elaina-theme-data` folder locally for build-time imports.
- `pnpm lint` passes with the existing JSDoc warning in `src/src/utils/fileSystem.ts`.
- Existing repository hook still reports the pre-existing wiki metadata warning for `disable-theme-wallpaper`.

## Notes

The repo's `package.json` still has a local `penguPath` that is invalid on my machine, so Vite logs an `ENOENT` during the optional post-build copy-to-Pengu step after producing `dist/`. The actual TypeScript/Vite build completes successfully.
